### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
   "perl" : "v6",
   "name" : "Algorithm::Trie::libdatrie",
+  "license" : "Artistic-2.0",
   "description" : "a character keyed trie using the datrie library.",
   "version" : "0.2",
   "source-url" : "git://github.com/zengargoyle/p6-Algorithm-Trie-libdatrie.git",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license